### PR TITLE
fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The file should look like the following
 [application]
 org=youriotorg
 id=yourdeviceid
-auth-method=apikey
+type=apikey
 auth-key=yourapikey
 auth-token=yourapitoken
 ```


### PR DESCRIPTION
IMHO the format of the config file has changed because I got te following error

>  python client.py 
> Traceback (most recent call last):
>   File "client.py", line 24, in <module>
>     options = ibmiotf.application.ParseConfigFile("/home/pi/device.cfg")
>   File "/usr/local/lib/python2.7/dist-packages/ibmiotf/application.py", line 513, in ParseConfigFile
>     appType = parms.get(sectionHeader, "type", "standalone")
>   File "/usr/lib/python2.7/ConfigParser.py", line 618, in get
>     raise NoOptionError(option, section)
> ConfigParser.NoOptionError: No option 'type' in section: 'application'

So when changing auth-method to type=apikey it works
